### PR TITLE
Add health check

### DIFF
--- a/src/model_service/app.py
+++ b/src/model_service/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request
+from flask import Flask, request, Response
 from model_service.model_wrapper import ModelService
 
 app = Flask(__name__)
@@ -17,3 +17,7 @@ def get_prediction():
     data = {"score": prediction.tolist()}
     print(data)
     return data
+
+@app.route("/ready", methods=["GET"])
+def is_ready():
+    return Response(status=200)

--- a/src/model_service/health.py
+++ b/src/model_service/health.py
@@ -1,0 +1,15 @@
+"""
+This script allows for testing whether the app has started, which is only after it has (downloaded and) started the models, which can take up to 15 seconds.
+This can then be used by Docker Compose to wait for it to be healthy.
+"""
+
+import requests
+import sys
+
+try:
+    r = requests.get('http://localhost:5000/ready', timeout=0.5)
+
+    if r.status_code != 200:
+        sys.exit(1)
+except Exception as e:
+    sys.exit(1)


### PR DESCRIPTION
This adds a script that can be used by Docker to check whether the model has finished starting up. This allow s adding a health check when running it in Docker Compose, which then allows us to only start the app or other dependent services when the model is ready.